### PR TITLE
Read from _config.yml for site.url

### DIFF
--- a/rss_url_filter.rb
+++ b/rss_url_filter.rb
@@ -1,7 +1,7 @@
 module Jekyll
   module RSSURLFilter
     def relative_urls_to_absolute(input)
-      url = "http://example.com"
+      url = Jekyll.configuration({})['url'] || 'http://example.com'
       input.gsub('src="/', 'src="' + url + '/').gsub('href="/', 'href="' + url + '/')
     end
   end


### PR DESCRIPTION
Prior to this PR, the end user would need to update this plugin per instance with the correct domain for the site. This PR reads the `url` property from the `_config.yml` file and applies it instead.